### PR TITLE
fix: Resolve Vue rendering and Ziggy routing errors

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -62,7 +62,7 @@ const showingNavigationDropdown = ref(false);
                                 <NavLink :href="route('admin.map-plot-editor.index')" :active="route().current().startsWith('admin.map-plot-editor')">
                                     Editor de Lotes
                                 </NavLink>
-                                <NavLink :href="route('admin.shop-requests.index')" :active="route().current().startsWith('admin.shop-requests')">
+                                <NavLink :href="route('shop-requests.index')" :active="route().current().startsWith('shop-requests.') || route().current() === 'shop-requests.index'">
                                     Solicitudes
                                 </NavLink>
                                 <NavLink :href="route('admin.shop-contracts.index')" :active="route().current().startsWith('admin.shop-contracts')">
@@ -198,7 +198,7 @@ const showingNavigationDropdown = ref(false);
                         <ResponsiveNavLink :href="route('admin.map-plot-editor.index')" :active="route().current().startsWith('admin.map-plot-editor')">
                             Editor de Lotes
                         </ResponsiveNavLink>
-                        <ResponsiveNavLink :href="route('admin.shop-requests.index')" :active="route().current().startsWith('admin.shop-requests')">
+                        <ResponsiveNavLink :href="route('shop-requests.index')" :active="route().current().startsWith('shop-requests.') || route().current() === 'shop-requests.index'">
                             Solicitudes
                         </ResponsiveNavLink>
                         <ResponsiveNavLink :href="route('admin.shop-contracts.index')" :active="route().current().startsWith('admin.shop-contracts')">

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -56,7 +56,7 @@ function handleImageError() {
                     </div>
                     <nav v-if="canLogin" class="-mx-3 flex flex-1 justify-end">
                         <Link
-                            v-if="$page.props.auth.user"
+                            v-if="$page.props.auth && $page.props.auth.user"
                             :href="route('dashboard')"
                             class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
                         >


### PR DESCRIPTION
This commit addresses two specific errors you reported:

1.  **Welcome.vue TypeError:**
    - I modified `resources/js/Pages/Welcome.vue`.
    - I changed the `v-if` condition for displaying user-specific links (like the "Dashboard" link) from `v-if="$page.props.auth?.user"` to the more robust `v-if="$page.props.auth && $page.props.auth.user"`. This prevents the "Cannot read properties of undefined (reading 'user')" error when the page is viewed by an unauthenticated guest.

2.  **AuthenticatedLayout.vue Ziggy Route Error:**
    - I modified `resources/js/Layouts/AuthenticatedLayout.vue`.
    - I corrected the `href` for the "Solicitudes" (Shop Requests) navigation link to use `route('shop-requests.index')` instead of `route('admin.shop-requests.index')`. This aligns with the actual route definition, which is not admin-namespaced to allow user access.
    - I updated the `:active` state check for this link accordingly to `route().current().startsWith('shop-requests.') || route().current() === 'shop-requests.index'`.

These fixes should improve the stability of the Welcome page for guests and ensure correct navigation for authenticated users within the admin panel.