### PR TITLE
fix: Prevent render error in AuthenticatedLayout

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -81,7 +81,7 @@ const showingNavigationDropdown = ref(false);
                                                 type="button"
                                                 class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
                                             >
-                                                {{ $page.props.auth.user.name }}
+                                                {{ ($page.props.auth && $page.props.auth.user) ? $page.props.auth.user.name : 'User' }}
 
                                                 <svg
                                                     class="-me-0.5 ms-2 h-4 w-4"
@@ -211,13 +211,15 @@ const showingNavigationDropdown = ref(false);
                         class="border-t border-gray-200 pb-1 pt-4"
                     >
                         <div class="px-4">
-                            <div
-                                class="text-base font-medium text-gray-800"
-                            >
+                            <div v-if="$page.props.auth && $page.props.auth.user" class="text-base font-medium text-gray-800">
                                 {{ $page.props.auth.user.name }}
                             </div>
-                            <div class="text-sm font-medium text-gray-500">
+                            <div v-if="$page.props.auth && $page.props.auth.user" class="text-sm font-medium text-gray-500">
                                 {{ $page.props.auth.user.email }}
+                            </div>
+                            <div v-if="!$page.props.auth || !$page.props.auth.user">
+                                <div class="text-base font-medium text-gray-800">User Name N/A</div>
+                                <div class="text-sm font-medium text-gray-500">Email N/A</div>
                             </div>
                         </div>
 


### PR DESCRIPTION
Addresses a TypeError: "Cannot read properties of undefined (reading 'user')" that could occur in `AuthenticatedLayout.vue` if `$page.props.auth` or `$page.props.auth.user` was unexpectedly undefined when trying to render your name and email in the responsive navigation section.

Modifications:
- Updated `resources/js/Layouts/AuthenticatedLayout.vue`:
  - Made access to `$page.props.auth.user.name` and `$page.props.auth.user.email` in the responsive navigation menu more robust by explicitly checking for the existence of `$page.props.auth` and `$page.props.auth.user` before attempting to access their properties.
  - Added fallback text if your data is not available in these display slots.
  - Ensured your name display in the primary navigation's settings dropdown also uses robust access with a fallback.

This change should prevent the dashboard page from appearing blank due to this rendering error.