### PR TITLE
fix: Standardize map image paths and provide API for map details

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -127,4 +127,22 @@ class MapController extends Controller
         $map->delete();
         return Redirect::route('admin.maps.index')->with('success', 'Map deleted.');
     }
+
+    /**
+     * API endpoint to get map details as JSON.
+     */
+    public function getMapDetailsApi(Map $map): JsonResponse
+    {
+        // Policy check could be added here if more granular control than route middleware is needed.
+        // e.g., $this->authorize('view', $map);
+
+        // Ensure necessary relationships are loaded, and only select fields needed by the editor.
+        $map->load('city:id,name');
+
+        // Return the map model. Laravel will automatically convert it to JSON.
+        // The model's $appends for image_path (if it uses an accessor to build full URL)
+        // should ensure the image_path is correctly formatted.
+        // If natural width/height are needed and stored on map model, they will be included.
+        return response()->json($map);
+    }
 }

--- a/database/seeders/MapSeeder.php
+++ b/database/seeders/MapSeeder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Seeder;
 use App\Models\City; // Import City model
 use App\Models\Map;   // Import Map model
 use Illuminate\Support\Str; // Import Str facade for slug generation
+use Illuminate\Support\Facades\Storage; // Import Storage facade
 
 class MapSeeder extends Seeder
 {
@@ -23,47 +24,26 @@ class MapSeeder extends Seeder
         }
 
         foreach ($cities as $city) {
-            // Generate a simple image path based on city name
-            // User will need to place actual images matching these paths in `storage/app/public/map_images/`
-            // And ensure `php artisan storage:link` has been run.
-            // The path saved here will be accessible via Storage::url() if stored like 'public/map_images/...'
-            // For simplicity, we'll store a relative path that implies it's in the public map images directory.
             $imageName = Str::slug($city->name) . '_map.jpg'; // e.g., bridgewatch_map.jpg
 
-            // This path assumes that when displayed, it will be prefixed by `storage/` (publicly accessible)
-            // and that the actual files are in `storage/app/public/map_images/`.
-            // The MapController's store method uses `Storage::url($path)` where $path is 'public/map_images/filename.jpg'.
-            // So, to be consistent for display, we should store the path as it would be after Storage::url(),
-            // but without the leading /storage. Or, ensure the model accessor for image_path always uses Storage::url().
-            // For simplicity, let's store the path as 'map_images/filename.jpg' and assume the model accessor
-            // or Vue component will prepend '/storage/' or use `Storage::url()` if the path doesn't start with http.
-            // The MapController store method saves it as Storage::url($path), which gives a full URL.
-            // To keep it simple and consistent with how the MapController saves it (which includes /storage/),
-            // we should aim for that. However, Storage::url() is for retrieving.
-            // When seeding, we just define the path *within* the public disk.
-            // So, 'map_images/' . $imageName is correct for the database if the accessor prepends Storage::url's base.
-            // Or, if the accessor expects a path already including /storage, then:
-            // $publicPath = 'map_images/' . $imageName;
-            // $imageStoragePathForDb = '/storage/' . $publicPath; // This is how it would look if Storage::url() was used on 'public/map_images/...'
-            // For now, let's stick to 'map_images/city_map.jpg' and let the model/controller handle full URL generation.
-            // The MapController's store method saves the full URL: `$data['image_path'] = Storage::url($path);`
-            // So this seeder should also save the full URL for consistency.
-            // BUT, Storage::url() is for *generating* URLs. We are *defining* the path.
-            // The convention is to store paths relative to the disk's root.
-            // If 'public' disk is used, 'map_images/...' is correct. The accessor should then use Storage::url().
+            // Path to be stored in DB. Assumes files are in `public/storage/map_images/`
+            // This path should be usable with asset() helper or directly as a public URL part.
+            $publicUrlPath = '/storage/map_images/' . $imageName;
 
-            $imagePathInPublicDisk = 'map_images/' . $imageName;
-
+            // For this to work, the user must:
+            // 1. Place corresponding image files in `storage/app/public/map_images/`
+            //    (e.g., storage/app/public/map_images/bridgewatch_map.jpg)
+            // 2. Run `php artisan storage:link` to create the symlink from `public/storage` to `storage/app/public`.
 
             Map::create([
                 'city_id' => $city->id,
                 'name' => 'Map of ' . $city->name,
-                'image_path' => $imagePathInPublicDisk, // Path relative to 'storage/app/public' or the 'public' disk root
+                'image_path' => $publicUrlPath, // Store the expected public URL path
                 'description' => 'Default map for the city of ' . $city->name,
-                // Assuming 'width' and 'height' (natural dimensions of the image) are nullable or have defaults.
-                // Ideally, these would be known or extracted from the actual image if possible during seeding.
+                // 'width' and 'height' (natural dimensions) are not set here.
+                // They could be set if known, or via a separate process that inspects images.
             ]);
         }
-        $this->command->info(count($cities) . ' maps created, one for each city.');
+        $this->command->info(count($cities) . ' maps created, one for each city, with public URL paths for images.');
     }
 }

--- a/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
+++ b/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
@@ -16,6 +16,7 @@ const cities = ref([]);
 const selectedCityId = ref(null);
 const mapsForCity = ref([]);
 const selectedMapId = ref(null);
+const selectedMap = ref(null); // Added to store full map details
 const selectedMapImageUrl = ref(null); // Will store the URL for the map image
 const mapPlots = ref([]);
 
@@ -82,17 +83,24 @@ const fetchMapDetailsAndPlots = async () => {
         return;
     }
     isLoadingMapDetails.value = true; isLoadingMapPlots.value = true;
-    selectedMapImageUrl.value = null; mapPlots.value = [];
+    selectedMapImageUrl.value = null; mapPlots.value = []; selectedMap.value = null;
+    mapImageNaturalDimensions.value = { width: 0, height: 0 }; // Reset dimensions
+    mapDisplayDimensions.value = { width: 0, height: 0 }; // Reset dimensions
+
     try {
-        // Assuming MapController@show returns JSON with image_path
-        const mapDetailsResponse = await axios.get(route('admin.maps.show', selectedMapId.value));
+        const mapDetailsResponse = await axios.get(route('admin.maps.details.api', selectedMapId.value));
+        selectedMap.value = mapDetailsResponse.data; // Store full map object
         selectedMapImageUrl.value = mapDetailsResponse.data.image_path;
+        // If map model includes natural width/height, they can be used here, e.g.,
+        // mapImageNaturalDimensions.value = { width: mapDetailsResponse.data.width, height: mapDetailsResponse.data.height };
+        // This would be better than relying solely on @load if dimensions are pre-stored.
 
         const plotsResponse = await axios.get(route('admin.map-plots.index', { map_id: selectedMapId.value }));
         mapPlots.value = plotsResponse.data.map_plots.data;
     } catch (error) {
         console.error("Error fetching map details or plots:", error);
         selectedMapImageUrl.value = null;
+        selectedMap.value = null;
     } finally {
         isLoadingMapDetails.value = false; isLoadingMapPlots.value = false;
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/map-plot-editor', function () { return Inertia::render('Admin/Maps/InteractiveMapPlotEditor'); })->name('map-plot-editor.index');
         Route::resource('shop-contracts', ShopContractController::class); // Added to admin group
         Route::resource('users', \App\Http\Controllers\Admin\UserController::class)->only(['index', 'create', 'store']);
+        Route::get('/maps/{map}/details', [MapController::class, 'getMapDetailsApi'])->name('maps.details.api'); // Added
         // Future admin routes can be added here
     });
 


### PR DESCRIPTION
This commit addresses issues related to map image display and data fetching for the interactive map plot editor.

1.  **MapSeeder Path Correction:**
    - Modified `database/seeders/MapSeeder.php` to store `image_path` for seeded maps with a leading `/storage/` prefix (e.g., `/storage/map_images/city-slug_map.jpg`). This makes the stored paths directly usable as public URLs and consistent with paths generated by `Storage::url()` for your user-uploaded map images.

2.  **Dedicated API Endpoint for Map Details:**
    - Added a new route `GET /admin/maps/{map}/details` named `admin.maps.details.api` within `routes/web.php`.
    - Implemented the `getMapDetailsApi(Map $map)` method in `app/Http/Controllers/MapController.php`. This method returns the specified map's details (including `image_path` and loaded city relation) as a JSON response.

3.  **InteractiveMapPlotEditor Update:**
    - Modified `resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue` to use the new `admin.maps.details.api` route for fetching the details of the selected map. This separates its data fetching logic from the `MapController@show` method intended for Inertia page views.

These changes ensure consistent handling of map image paths and provide a reliable way for the map plot editor to obtain necessary map data, resolving issues where map images might not load correctly in the editor or other views.