### PR TITLE
fix: Correct map image URL generation and resolve JS error in map editor

### DIFF
--- a/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
+++ b/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
@@ -84,8 +84,8 @@ const fetchMapDetailsAndPlots = async () => {
     }
     isLoadingMapDetails.value = true; isLoadingMapPlots.value = true;
     selectedMapImageUrl.value = null; mapPlots.value = []; selectedMap.value = null;
-    mapImageNaturalDimensions.value = { width: 0, height: 0 }; // Reset dimensions
-    mapDisplayDimensions.value = { width: 0, height: 0 }; // Reset dimensions
+    // Reset all properties of the single mapImageDimensions ref
+    mapImageDimensions.value = { width: 0, height: 0, naturalWidth: 0, naturalHeight: 0 };
 
     try {
         const mapDetailsResponse = await axios.get(route('admin.maps.details.api', selectedMapId.value));

--- a/resources/js/Pages/Admin/Maps/Show.vue
+++ b/resources/js/Pages/Admin/Maps/Show.vue
@@ -43,10 +43,10 @@ defineProps({
                         </div>
                         <div v-if="map.image_path">
                             <strong class="font-semibold text-gray-700">Image Preview:</strong><br/>
-                            <img :src="map.image_path.startsWith('http') ? map.image_path : ('/storage/' + map.image_path.replace(/^public\//, ''))"
+                            <img :src="map.image_path"
                                  :alt="map.name"
                                  class="mt-2 max-w-md w-full max-h-[60vh] border p-1 rounded-md object-contain"/>
-                            <p class="text-xs text-gray-500 mt-1">Note: Image preview assumes path is correctly stored for public access (e.g., via `storage:link`). If using `Storage::url()`, the `image_path` prop should already be a full URL.</p>
+                            <p class="text-xs text-gray-500 mt-1">Note: Image path is: {{ map.image_path }}. Ensure it's a public URL (e.g., starts with /storage/ or http).</p>
                         </div>
                          <div>
                             <strong class="font-semibold text-gray-700">Natural Width (px):</strong>


### PR DESCRIPTION
This commit addresses two issues related to displaying map images and the functionality of the Interactive Map Plot Editor:

1.  **Map Image URL Duplication (`/storage//storage/`):**
    - I modified `resources/js/Pages/Admin/Maps/Show.vue`. The `:src` binding for displaying the map image now uses `map.image_path` directly. This corrects an issue where an extra `/storage/` prefix might have been added by the Vue component to an `image_path` that already contained the full public URL (e.g., `/storage/map_images/filename.jpg`), which was causing doubled prefixes.
    - I verified that `MapSeeder.php` correctly stores `image_path` as the full public URL (e.g., `/storage/map_images/filename.jpg`), and that `app/Models/Map.php` does not have an accessor that would further modify this path by incorrectly prepending another `/storage/`.

2.  **JavaScript Error in InteractiveMapPlotEditor:**
    - I corrected a `ReferenceError` in `resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue`.
    - I ensured that reactive refs (`mapImageDimensions.value`) are correctly accessed and updated using `.value` within the `fetchMapDetailsAndPlots()` method when resetting image dimension data. Specifically, `mapImageDimensions.value` is now reset with all its expected properties (`width`, `height`, `naturalWidth`, `naturalHeight`).

These changes should ensure map images are referenced with correct URLs throughout the admin interface and resolve the JavaScript error that was affecting the map plot editor's functionality.