### PR TITLE
fix: Improve MapPlot editor UX and resolve pagination error

### DIFF
--- a/app/Http/Controllers/MapPlotController.php
+++ b/app/Http/Controllers/MapPlotController.php
@@ -54,16 +54,16 @@ class MapPlotController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(StoreMapPlotRequest $request): JsonResponse
+    public function store(StoreMapPlotRequest $request): RedirectResponse
     {
         $this->authorize('create', MapPlot::class);
         $data = $request->validated();
         // Ensure 'is_active' defaults to true if not provided or if it's not boolean from form
         $data['is_active'] = filter_var($request->input('is_active', true), FILTER_VALIDATE_BOOLEAN);
 
-        $mapPlot = MapPlot::create($data);
-        $mapPlot->load('map:id,name'); // Load map for context in response
-        return response()->json($mapPlot, 201);
+        MapPlot::create($data);
+        // $mapPlot->load('map:id,name'); // Not needed for redirect back
+        return redirect()->back()->with('success', 'Map plot created successfully.');
     }
 
     /**
@@ -91,7 +91,7 @@ class MapPlotController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(UpdateMapPlotRequest $request, MapPlot $mapPlot): JsonResponse
+    public function update(UpdateMapPlotRequest $request, MapPlot $mapPlot): RedirectResponse
     {
         $this->authorize('update', $mapPlot);
         $data = $request->validated();
@@ -101,17 +101,17 @@ class MapPlotController extends Controller
         }
 
         $mapPlot->update($data);
-        $mapPlot->load('map:id,name'); // Load map for context in response
-        return response()->json($mapPlot);
+        // $mapPlot->load('map:id,name'); // Not needed for redirect back
+        return redirect()->back()->with('success', 'Map plot updated successfully.');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(MapPlot $mapPlot): JsonResponse
+    public function destroy(MapPlot $mapPlot): RedirectResponse
     {
         $this->authorize('delete', $mapPlot);
         $mapPlot->delete();
-        return response()->json(null, 204);
+        return redirect()->back()->with('success', 'Map plot deleted successfully.');
     }
 }

--- a/resources/js/Pages/Admin/ShopContracts/Index.vue
+++ b/resources/js/Pages/Admin/ShopContracts/Index.vue
@@ -55,15 +55,27 @@
                                     </tr>
                                 </tbody>
                             </table>
-                             <!-- Pagination -->
-                            <div class="mt-4 flex justify-between" v-if="shopContracts.links">
-                                <Link v-for="(link, index) in shopContracts.links" :key="index"
-                                      :href="link.url"
-                                      v-html="link.label"
-                                      class="px-3 py-2 text-sm rounded-md"
-                                      :class="{ 'bg-indigo-600 text-white': link.active, 'text-gray-700 bg-white border border-gray-300 hover:bg-gray-50': !link.active, 'opacity-50 cursor-not-allowed': !link.url }"
-                                      :disabled="!link.url"
-                                      preserve-scroll />
+                            <!-- Pagination Links -->
+                            <div class="mt-6 flex justify-center space-x-1" v-if="shopContracts.links && shopContracts.links.length > 3">
+                                 <template v-for="(link, key) in shopContracts.links" :key="key">
+                                    <Link
+                                        v-if="link.url"
+                                        :href="link.url"
+                                        v-html="link.label"
+                                        class="px-4 py-2 text-sm rounded-md"
+                                        :class="{
+                                            'bg-indigo-600 text-white': link.active,
+                                            'text-gray-700 bg-white border border-gray-300 hover:bg-gray-50': !link.active,
+                                        }"
+                                        preserve-scroll
+                                    />
+                                    <span
+                                        v-else
+                                        v-html="link.label"
+                                        class="px-4 py-2 text-sm rounded-md text-gray-400 cursor-default border border-gray-300"
+                                        :class="{ 'bg-indigo-600 text-white': link.active }"
+                                    ></span>
+                                </template>
                             </div>
                         </div>
                         <div v-else class="text-gray-500">


### PR DESCRIPTION
This commit includes several fixes and improvements based on user testing:

1.  **MapPlotController Response Types:**
    - Modified `app/Http/Controllers/MapPlotController.php`.
    - The `store`, `update`, and `destroy` methods now return `RedirectResponse` (e.g., `redirect()->back()->with('success', ...)`) instead of `JsonResponse`. This aligns with Inertia's `useForm` helper expectations, ensuring that after creating, updating, or deleting map plots via the interactive editor, the page/form state is correctly handled by Inertia (triggering `onSuccess` callbacks, etc.).

2.  **ShopContracts Pagination:**
    - Updated `resources/js/Pages/Admin/ShopContracts/Index.vue`.
    - Corrected the pagination link rendering to robustly handle null URLs (e.g., for "Previous" on the first page or "..." links), preventing the "Invalid prop: type check failed for prop 'href'" error. This is achieved by conditionally rendering a `<span>` for non-clickable pagination items.

3.  **InteractiveMapPlotEditor Resize Handling:**
    - Enhanced `resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue`: - Added `ref="mapImageRef"` to the map `<img>` tag and applied responsive styling. - Implemented a `ResizeObserver` to dynamically track the displayed dimensions of the map image. - The `onMapImageLoad` function now accurately captures both natural and initial display dimensions. - The `getPlotStyle` method consistently uses these dynamic display dimensions in conjunction with the natural dimensions to correctly scale and position plot markers, ensuring they remain aligned with the map image features even when the browser window is resized. - The `watch` effect on `selectedMapImageUrl` was improved to correctly manage the `ResizeObserver` instance when the map image changes.