### PR TITLE
fix: Correct template syntax error in InteractiveMapPlotEditor

### DIFF
--- a/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
+++ b/resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue
@@ -346,7 +346,7 @@ watch(selectedMapImageUrl, (newUrl) => {
                                 :src="selectedMapImageUrl"
                                 alt="Selected Map"
                                 @load="onMapImageLoad"
-                                class="block w-full h-auto object-contain" <!-- Responsive image -->
+                                class="block w-full h-auto object-contain"
                                 :style="{ 'max-height': '70vh' }"
                             />
 


### PR DESCRIPTION
Resolves an `InvalidCharacterError` caused by a misplaced HTML comment within the `class` attribute of the main map `<img>` tag in `resources/js/Pages/Admin/Maps/InteractiveMapPlotEditor.vue`.

The erroneous line:
  `class="block w-full h-auto object-contain" <!-- Responsive image -->`
was corrected to:
  `class="block w-full h-auto object-contain"`

This fix prevents Vue's template parser from attempting to set an attribute named `<!--`, which was leading to critical rendering errors and subsequent JavaScript failures within the component.